### PR TITLE
Move flex declaration to tablet view (#1)

### DIFF
--- a/scss/style.scss
+++ b/scss/style.scss
@@ -70,7 +70,6 @@
 }
 
 .privacy-manager-dialog-configuration-comparison {
-    display: flex;
     margin-top: 20px;
 }
 
@@ -81,12 +80,14 @@
 }
 
 .privacy-manager-actions {
-    width: 50%;
+    width: 100%;
     padding-left: 20px;
     padding-right: 20px;
     min-width: 0;
-    flex-grow: 1;
-    flex-shrink: 0;
+    
+    & + .privacy-manager-actions {
+        margin-top: 20px;
+    }
 }
 
 .privacy-manager-action {
@@ -168,6 +169,22 @@
     background-color: rgba($bg-dark, .2);
     z-index: 1;
     overflow-y: auto;
+}
+
+@media screen and (min-width:600px) {
+    .privacy-manager-dialog-configuration-comparison {
+        display: flex;
+    }
+
+    .privacy-manager-actions {
+        width: 50%;
+        flex-grow: 1;
+        flex-shrink: 0
+            
+        & + .privacy-manager-actions {
+            margin-top: 0;
+        }
+    }
 }
 
 @media screen and (min-width: 900px) {


### PR DESCRIPTION
# Description

Displaying allowed/forbidden actions side by side on a mobile screen results in small text, unreadable for the user. A better way is to display them below each other and move the side-by-side view to a wider screen width.

## Before
![before](https://user-images.githubusercontent.com/984069/40423409-cf2c5bdc-5e92-11e8-9c20-8577700b0fa9.png)

## After
![after](https://user-images.githubusercontent.com/984069/40423459-f352cfdc-5e92-11e8-90e6-8ff85f4fb4bd.png)